### PR TITLE
Battery voltage reader function in fc_interface now

### DIFF
--- a/CONTRIBUTING.c
+++ b/CONTRIBUTING.c
@@ -49,10 +49,10 @@
 * [brief purpose of function]
 *
 * Inputs:
-* [input arguments and any relevant explantion]
+* [input arguments and any relevant explanation]
 *
 * Returns:
-* [return values and any relevant explantion]
+* [return values and any relevant explanation]
 *
 * Implementation:
 * [explain key steps of function]

--- a/RobotNoASF/Interfaces/adc_interface.c
+++ b/RobotNoASF/Interfaces/adc_interface.c
@@ -46,10 +46,15 @@ void adcSingleConvInit(void)
 	=	0x41444300;						//Disable ADC write protect
 	REG_PMC_PCER0
 	|=	(1<<ID_ADC);					//Enable peripheral clock on ADC
-	REG_ADC_MR
+	REG_ADC_MR							//ADC mode register
 	|=	ADC_MR_PRESCAL(49)				//Prescale ADC conversion by 49 (100MHZ/((49+1)x2))=1MHZ.
 	|	ADC_MR_STARTUP_SUT24			//Startup time is 24 ADC clock cycles.
-	|	ADC_MR_TRANSFER(2);				//Transfer field must be programmed with value 2.	
+	|	ADC_MR_TRANSFER(2);				//Transfer field must be programmed with value 2.
+	REG_ADC_ACR							//Analogue control register
+	=	ADC_ACR_IRVCE					//Internal ref voltage change enable
+	|	ADC_ACR_IRVS(IRVS_3396)			//Mode 8 is 3.396V. If changed be sure to set 
+										//ADC_VOLTAGE_REF appropriately
+	|	ADC_ACR_ONREF;					//Internal reference voltage is on
 }
 
 /*

--- a/RobotNoASF/Interfaces/adc_interface.c
+++ b/RobotNoASF/Interfaces/adc_interface.c
@@ -50,11 +50,12 @@ void adcSingleConvInit(void)
 	|=	ADC_MR_PRESCAL(49)				//Prescale ADC conversion by 49 (100MHZ/((49+1)x2))=1MHZ.
 	|	ADC_MR_STARTUP_SUT24			//Startup time is 24 ADC clock cycles.
 	|	ADC_MR_TRANSFER(2);				//Transfer field must be programmed with value 2.
-	REG_ADC_ACR							//Analogue control register
-	=	ADC_ACR_IRVCE					//Internal ref voltage change enable
-	|	ADC_ACR_IRVS(IRVS_3396)			//Mode 8 is 3.396V. If changed be sure to set 
-										//ADC_VOLTAGE_REF appropriately
-	|	ADC_ACR_ONREF;					//Internal reference voltage is on
+	//REG_ADC_ACR						//Analogue control register. Sets up internal voltage ref.
+										////Seems to be unnecessary.
+	//=	ADC_ACR_IRVCE					//Internal ref voltage change enable
+	//|	ADC_ACR_IRVS(IRVS_3396)			//Mode 8 is 3.396V. If changed be sure to set 
+										////ADC_VOLTAGE_REF appropriately
+	//|	ADC_ACR_ONREF;					//Internal reference voltage is on
 }
 
 /*
@@ -68,7 +69,7 @@ void adcSingleConvInit(void)
 *   Channel number of the desired ADC channel (0-15)
 *
 * Returns:
-* 12bit value of the ADC channel in question (0-4095)
+* 10bit value of the ADC channel in question (0-1023)
 *
 * Implementation:
 * - Sets the ADC mux channel to read

--- a/RobotNoASF/Interfaces/adc_interface.h
+++ b/RobotNoASF/Interfaces/adc_interface.h
@@ -64,7 +64,7 @@
 #define IRVS_3396			0x8	//3396mV
 
 //	ADC Reference Voltage Setting
-#define ADC_VOLTAGE_REF		3396	//Reference voltage (mV) used by ADC. Must be changed if 
+#define ADC_VOLTAGE_REF		3300	//Reference voltage (mV) used by ADC. Must be changed if 
 									//reference voltage is changed. Will be used for system wide ADC
 									//voltage conversions.
 ///////////////Functions////////////////////////////////////////////////////////////////////////////
@@ -94,7 +94,7 @@ void adcSingleConvInit(void);
 *   Channel number of the desired ADC channel (0-15)
 *
 * Returns:
-* 12bit value of the ADC channel in question (0-4095)
+* 10bit value of the ADC channel in question (0-1023)
 *
 */
 uint16_t adcRead(uint8_t channel);

--- a/RobotNoASF/Interfaces/adc_interface.h
+++ b/RobotNoASF/Interfaces/adc_interface.h
@@ -45,6 +45,28 @@
 #define FC_BATVOLT_ADC_CH	14	// Battery voltage level
 #define FC_BATTEMP_ADC_CH	9	// Battery temperature
 
+//	ADC Internal Reference Voltage Settings
+#define IRVS_1578			0x7	//1578mV
+#define IRVS_1699			0x6	//1699mV
+#define IRVS_1820			0x5	//1820mV
+#define IRVS_1941			0x4	//1941mV
+#define IRVS_2063			0x3	//2063mV
+#define IRVS_2184			0x2	//2184mV
+#define IRVS_2305			0x1	//2305mV
+#define IRVS_2426			0x0	//2426mV
+#define IRVS_2547			0xF	//2547mV
+#define IRVS_2669			0xE	//2669mV
+#define IRVS_2790			0xD	//2790mV
+#define IRVS_2911			0xC	//2790mV
+#define IRVS_3032			0xB	//3032mV
+#define IRVS_3154			0xA	//3154mV
+#define IRVS_3275			0x9	//3275mV
+#define IRVS_3396			0x8	//3396mV
+
+//	ADC Reference Voltage Setting
+#define ADC_VOLTAGE_REF		3396	//Reference voltage (mV) used by ADC. Must be changed if 
+									//reference voltage is changed. Will be used for system wide ADC
+									//voltage conversions.
 ///////////////Functions////////////////////////////////////////////////////////////////////////////
 /*
 * Function:

--- a/RobotNoASF/Interfaces/fc_interface.c
+++ b/RobotNoASF/Interfaces/fc_interface.c
@@ -15,6 +15,7 @@
 * Functions:
 * void fcInit(void)
 * void fcWatchdogReset(void)
+* uint16_t fcBatteryVoltage(void)
 *
 */
 

--- a/RobotNoASF/Interfaces/fc_interface.c
+++ b/RobotNoASF/Interfaces/fc_interface.c
@@ -124,3 +124,32 @@ uint8_t fcVersionRead(void)
 	//Return just the revision number (first 3 bits)
 	return (0x07 & returnVal);
 }
+
+/*
+* Function:
+* float fcBatteryVoltage(void)
+*
+* Returns current battery voltage
+*
+* Inputs:
+* none
+*
+* Returns:
+* Returns a integer value of the current battery voltage in mV.
+*
+* Implementation:
+* Reads battery voltage ADC channel
+* Converts to millivolts using linear conversion factor set in fc_interface.h and returns
+*
+* Improvements:
+* TODO: fcBatteryVoltage(); Curently this function is not capable of returning a value greater than
+* 3396mV because the ADC's internal reference voltage is only 3396mV max. To return full battery
+* voltage, there needs to be a higher reference voltage that doesn't degrade as the battery does.
+*
+*/
+uint16_t fcBatteryVoltage(void)
+{
+	uint16_t rawBattReading = 0;
+	rawBattReading = adcRead(FC_BATVOLT_ADC_CH);
+	return rawBattReading*FC_BATTVOL_CONV;
+}

--- a/RobotNoASF/Interfaces/fc_interface.c
+++ b/RobotNoASF/Interfaces/fc_interface.c
@@ -142,11 +142,6 @@ uint8_t fcVersionRead(void)
 * Reads battery voltage ADC channel
 * Converts to millivolts using linear conversion factor set in fc_interface.h and returns
 *
-* Improvements:
-* TODO: fcBatteryVoltage(); Curently this function is not capable of returning a value greater than
-* 3396mV because the ADC's internal reference voltage is only 3396mV max. To return full battery
-* voltage, there needs to be a higher reference voltage that doesn't degrade as the battery does.
-*
 */
 uint16_t fcBatteryVoltage(void)
 {

--- a/RobotNoASF/Interfaces/fc_interface.h
+++ b/RobotNoASF/Interfaces/fc_interface.h
@@ -42,6 +42,10 @@
 #define FC_BATTVOL_INIT	0x66	//Vreg = 3.98v, input current = 2.5A (FC_BATVOL_REG)
 #define FC_CHARGE_INIT	0xFA	//charge current set to max Ic=2875mA, termination current
 								//Iterm=100mA (default) (FC_CHARGE_REG)
+								
+//Misc
+//	ADC to battery voltage conversion factor
+#define FC_BATTVOL_CONV	ADC_VOLTAGE_REF/1023
 
 ///////////////Functions////////////////////////////////////////////////////////////////////////////
 /*

--- a/RobotNoASF/Interfaces/fc_interface.h
+++ b/RobotNoASF/Interfaces/fc_interface.h
@@ -16,6 +16,7 @@
 * Functions:
 * void fcInit(void)
 * void fcWatchdogReset(void)
+* uint16_t fcBatteryVoltage(void)
 *
 */
 
@@ -102,5 +103,20 @@ void fcWatchdogReset(void);
 *
 */
 uint8_t fcVersionRead(void);
+
+/*
+* Function:
+* float fcBatteryVoltage(void)
+*
+* Returns current battery voltage
+*
+* Inputs:
+* none
+*
+* Returns:
+* Returns a integer value of the current battery voltage in mV.
+*
+*/
+uint16_t fcBatteryVoltage(void);
 
 #endif /* FC_INTERFACE_H_ */

--- a/RobotNoASF/Interfaces/fc_interface.h
+++ b/RobotNoASF/Interfaces/fc_interface.h
@@ -45,10 +45,12 @@
 								//Iterm=100mA (default) (FC_CHARGE_REG)
 								
 //Misc
-//	ADC to battery voltage conversion factor. The 3.7 is derived from a voltage divider formed by
-//	R54 and R55 on the top board that scales down the voltage to be within range of the ADVREF
-// (0V - 3.396V)
-#define FC_BATTVOL_CONV	3.7*ADC_VOLTAGE_REF/1023.0
+//	ADC to battery voltage conversion factor. The 1.515 is derived by dividing measured battery
+//	voltage by the voltage measured at BV on the top board. The voltage at BV is scaled down from
+//	the battery voltage by a voltage divider formed by R54 and R55 on the top board to be within
+//	range of the ADVREF (0V - 3.396V). This is giving an accurate battery voltage reading on the
+//	red robot at the time of writing 02/08/17
+#define FC_BATTVOL_CONV	1.515*ADC_VOLTAGE_REF/1023.0
 
 ///////////////Functions////////////////////////////////////////////////////////////////////////////
 /*

--- a/RobotNoASF/Interfaces/fc_interface.h
+++ b/RobotNoASF/Interfaces/fc_interface.h
@@ -45,8 +45,10 @@
 								//Iterm=100mA (default) (FC_CHARGE_REG)
 								
 //Misc
-//	ADC to battery voltage conversion factor
-#define FC_BATTVOL_CONV	ADC_VOLTAGE_REF/1023
+//	ADC to battery voltage conversion factor. The 3.7 is derived from a voltage divider formed by
+//	R54 and R55 on the top board that scales down the voltage to be within range of the ADVREF
+// (0V - 3.396V)
+#define FC_BATTVOL_CONV	3.7*ADC_VOLTAGE_REF/1023.0
 
 ///////////////Functions////////////////////////////////////////////////////////////////////////////
 /*

--- a/RobotNoASF/swarm_robot_V2.cproj
+++ b/RobotNoASF/swarm_robot_V2.cproj
@@ -39,7 +39,7 @@
       </framework-data>
     </AsfFrameworkConfig>
     <avrtool>com.atmel.avrdbg.tool.atmelice</avrtool>
-    <avrtoolserialnumber>J41800047224</avrtoolserialnumber>
+    <avrtoolserialnumber>J41800047448</avrtoolserialnumber>
     <avrdeviceexpectedsignature>0x295B0AE0</avrdeviceexpectedsignature>
     <com_atmel_avrdbg_tool_jtagice3plus>
       <ToolOptions>
@@ -52,8 +52,7 @@
       <ToolNumber>J30200015825</ToolNumber>
       <ToolName>JTAGICE3</ToolName>
     </com_atmel_avrdbg_tool_jtagice3plus>
-    <avrtoolinterface>
-    </avrtoolinterface>
+    <avrtoolinterface>JTAG</avrtoolinterface>
     <avrtoolinterfaceclock>7500000</avrtoolinterfaceclock>
     <com_atmel_avrdbg_tool_atmelice>
       <ToolOptions>
@@ -63,7 +62,7 @@
         <InterfaceName>JTAG</InterfaceName>
       </ToolOptions>
       <ToolType>com.atmel.avrdbg.tool.atmelice</ToolType>
-      <ToolNumber>J41800047224</ToolNumber>
+      <ToolNumber>J41800047448</ToolNumber>
       <ToolName>Atmel-ICE</ToolName>
     </com_atmel_avrdbg_tool_atmelice>
   </PropertyGroup>


### PR DESCRIPTION
This function will output battery voltage as an integer in millivolts. Is tested and calibrated with the Red robot (3-V2). As far as I can gather the battery voltage circuit is unchanged between revisions so this should work on all the bots. The voltage derived and the voltage calculated from the voltage divider differ which implies that there might be some leakage current through the over voltage zener diode which has also been factored in.