### PR TITLE
Timer0 improvements

### DIFF
--- a/RobotNoASF/Interfaces/imu_interface.c
+++ b/RobotNoASF/Interfaces/imu_interface.c
@@ -52,18 +52,11 @@
 #include "../IMU-DMP/inv_mpu_dmp_motion_driver_CUSTOM.h"//Direct Motion Processing setup functions
 #include "../IMU-DMP/inv_mpu_CUSTOM.h"//IMU basic setup and initialisation functions
 
-//Flags and system globals
-uint32_t systemTimestamp = 0;	//Number of ms since powerup. Used by delay_ms and get_ms functions
-								//Which in turn are used by the IMU drivers/DMP
+
 
 uint8_t checkImuFifo	= 0;	//A flag to determine that the IMU's FIFO is ready to be read again
 
-#if defined ROBOT_TARGET_V1
-uint32_t imuFifoNextReadTime = 0;//The system time at which the IMU will be read next (ie when 
-								//checkImuFifo will next be set to one. Used by the V1 robot
-								//only as the V2 sets checkImuInfo from external interrupt from
-								//The IMU.
-#endif
+
 
 ///////////////Functions////////////////////////////////////////////////////////////////////////////
 /*
@@ -101,49 +94,6 @@ int imuInit(void)
 	result += mpu_set_compass_sample_rate(100);			// Set 100Hz compass sample rate (max)
 	
 	return result;
-}
-
-/*
-* Function:
-* void timer0Init(void)
-*
-* initialise timer0. will be moved to its own module soon
-*
-* Inputs:
-* none
-*
-* Returns:
-* none
-*
-* Implementation:
-* TODO:[explain key steps of function] timer0 init
-* [use heavy detail for anything complicated]
-*
-* Improvements:
-* Move to its own module.
-*
-*/
-void timer0Init(void)
-{	
-	////TIMER0////
-	//Timer0 is used for delay_ms and get_ms functions required by the imu driver
-	REG_PMC_PCER0
-	|=	(1<<ID_TC0);						//Enable TC clock (ID_TC0 is the peripheral identifier
-	//for timer counter 0)
-	NVIC_EnableIRQ(ID_TC0);					//Enable interrupt vector for TIMER0
-	REG_TC0_CMR0							//TC Channel Mode Register (Pg877)
-	|=	TC_CMR_TCCLKS_TIMER_CLOCK3			//Prescaler MCK/32 (100MHz/32 = 3.125MHz)
-	|	TC_CMR_WAVE							//Waveform mode
-	|	TC_CMR_WAVSEL_UP_RC;				//Clear on RC compare
-	REG_TC0_IER0							//TC interrupt enable register
-	|=	TC_IER_CPCS;						//Enable Register C compare interrupt
-	REG_TC0_RC0								//Set Register C (the timer counter value at which the
-	//interrupt will be triggered)
-	=	3125;								//Trigger once every 1/1000th of a second
-	//(100Mhz/32/1000)
-	REG_TC0_CCR0							//Clock control register
-	|=	TC_CCR_CLKEN						//Enable the timer clk.
-	|	TC_CCR_SWTRG;
 }
 
 /*
@@ -371,56 +321,7 @@ void getEulerAngles(long *ptQuat, euler_packet_t *eulerAngle)
 	eulerAngle->roll = (atan2(2*x*w-2*y*z , -sqx + sqy - sqz + sqw))*180/M_PI;
 }
 
-/*
-* Function: int get_ms(uint32_t *timestamp)
-*
-* Required by the IMU drivers (hence naming convention). Outputs the system uptime generated from 
-* Timer0.
-*
-* Inputs:
-* address of an integer where the timestamp will be stored
-*
-* Returns:
-* function will return 1 if invalid pointer is passed, otherwise a 0 on success
-*
-* Implementation:
-* Retrieves the value stored in systemTimestamp (stores the number of millisecs that have elapsed
-* since power on) and drops it at the address given by *timestamp. if *timestamp is an invalid
-* address then returns a 1.
-*
-*/
-int get_ms(uint32_t *timestamp)
-{
-	if(!timestamp)
-		return 1;	
-	*timestamp = systemTimestamp;
-	return 0;
-}
 
-
-/*
-* Function: int delay_ms(uint32_t period_ms)
-*
-* Required by the IMU drivers (hence naming convention). Halts execution for desired number of
-* milliseconds.
-*
-* Inputs:
-* period_ms is the number of milliseconds to wait
-*
-* Returns:
-* Always returns 0
-*
-* Implementation:
-* Stores systemTimestamp at the start of the function, then waits until systemTimestamp has
-* increased by the amount given in period_ms before continuing.
-*
-*/
-int delay_ms(uint32_t period_ms)
-{
-	uint32_t startTime = systemTimestamp;
-	while(systemTimestamp < (startTime + period_ms));
-	return 0;
-}
 
 /*
 * Function: char twiWriteImu(unsigned char slave_addr, unsigned char reg_addr, 
@@ -634,48 +535,6 @@ uint8_t imuCommTest(void)
 	return returnVal;				//return 0x71 on success
 }
 
-/*
-* Function: void TC0_Handler()
-*
-* Interrupt handler for Timer0. Is used to help implement get_ms() and delay_ms() functions
-* required by the IMU driver. Is also used to trigger reading the IMU's FIFO buffer (until 
-* hardware interrupts are implemented). The only interrupt on Timer0 is on Register C compare,
-* which will trigger an interrupt once every millisecond
-*
-* Inputs:
-* none
-*
-* Returns:
-* Increments systemTimestamp once every millisecond.
-*
-* Implementation:
-* If the RC compare flag is set then it increments the systemTimestamp, and also checks if 5ms
-* has elapsed. If so, will set a flag to read from the IMU's FIFO buffer (unimplemented)
-*
-*/
-void TC0_Handler()
-{
-	//The interrupt handler for timer counter 0
-	//Triggers every 1ms
-	if(REG_TC0_SR0 & TC_SR_CPCS)									//If RC compare flag
-	{
-		systemTimestamp++;
-		streamDelayCounter++;
-		if(streamDelayCounter == 100) //used for streaming data
-		{
-			streamDelayCounter = 0;
-			streamIntervalFlag = 1;
-		}
-//V1 robot doesn't have the IMU's interrupt pin tied in to the uC, so the FIFO will have to be
-//polled. V2 does utilise an external interrupt, so this code is not necessary.
-#if defined ROBOT_TARGET_V1
-		//Read IMUs FIFO every 5ms on the V1 platform
-		if(systemTimestamp >= (imuFifoNextReadTime + 5))					
-		{
-			imuFifoNextReadTime = systemTimestamp;
-		}
-#endif
-	}
-}
+
 
 

--- a/RobotNoASF/Interfaces/imu_interface.h
+++ b/RobotNoASF/Interfaces/imu_interface.h
@@ -73,27 +73,7 @@ typedef struct euler_packet
 */
 int imuInit(void);
 
-/*
-* Function:
-* void timer0Init(void)
-*
-* initialise timer0. will be moved to its own module soon
-*
-* Inputs:
-* none
-*
-* Returns:
-* none
-*
-* Implementation:
-* TODO:[explain key steps of function] timer0 init
-* [use heavy detail for anything complicated]
-*
-* Improvements:
-* Move to its own module.
-*
-*/
-void timer0Init(void);
+
 
 /*
 * Function: int imuDmpInit(void)
@@ -189,35 +169,6 @@ unsigned short invRow2Scale(const signed char *row);
 */
 void getEulerAngles(long *ptQuat, euler_packet_t *eulerAngle);
 
-/*
-* Function: int get_ms(uint32_t *timestamp)
-*
-* Required by the IMU drivers (hence naming convention). Outputs the system uptime generated from
-* Timer0.
-*
-* Inputs:
-* address of an integer where the timestamp will be stored
-*
-* Returns:
-* function will return 1 if invalid pointer is passed, otherwise a 0 on success
-*
-*/
-int get_ms(uint32_t *timestamp);
-
-/*
-* Function: int delay_ms(uint32_t period_ms)
-*
-* Required by the IMU drivers (hence naming convention). Halts execution for desired number of
-* milliseconds.
-*
-* Inputs:
-* period_ms is the number of milliseconds to wait
-*
-* Returns:
-* Always returns 0
-*
-*/
-int delay_ms(uint32_t period_ms);
 
 /*
 * Function: char twiWriteImu(unsigned char slave_addr, unsigned char reg_addr,
@@ -275,21 +226,6 @@ char twiReadImu(unsigned char slave_addr, unsigned char reg_addr,
 */
 uint8_t imuCommTest(void);
 
-/*
-* Function: void TC0_Handler()
-*
-* Interrupt handler for Timer0. Is used to help implement get_ms() and delay_ms() functions
-* required by the IMU driver. Is also used to trigger reading the IMU's FIFO buffer (until
-* hardware interrupts are implemented). The only interrupt on Timer0 is on Register C compare,
-* which will trigger an interrupt once every millisecond
-*
-* Inputs:
-* none
-*
-* Returns:
-* Increments systemTimestamp once every millisecond.
-*
-*/
-void TC0_Handler();
+
 
 #endif /* IMU_INTERFACE_H_ */

--- a/RobotNoASF/Interfaces/timer0.c
+++ b/RobotNoASF/Interfaces/timer0.c
@@ -1,9 +1,20 @@
 /*
- * timer0.c
- *
- * Created: 6/08/2017 1:23:13 PM
- *  Author: adams
- */ 
+* timer0.c
+*
+* Author : Adam Parlane and Matthew Witt
+* Created: 6/08/2017 2:01:45 PM
+*
+* Project Repository: https://github.com/AdamParlane/aut-swarm-robotics
+*
+* Provides functions for setting up the timer0 and delay functions
+*
+* More Info:
+* Atmel SAM 4N Processor Datasheet:http://www.atmel.com/Images/Atmel-11158-32-bit%20Cortex-M4-Microcontroller-SAM4N16-SAM4N8_Datasheet.pdf
+*
+* TODO: Provide details
+*
+*
+*/
 
 #include "timer0.h"
 
@@ -25,7 +36,7 @@
 * [use heavy detail for anything complicated]
 *
 * Improvements:
-* Move to its own module.
+* Commenting
 *
 */
 void timer0Init(void)

--- a/RobotNoASF/Interfaces/timer0.c
+++ b/RobotNoASF/Interfaces/timer0.c
@@ -1,0 +1,147 @@
+/*
+ * timer0.c
+ *
+ * Created: 6/08/2017 1:23:13 PM
+ *  Author: adams
+ */ 
+
+#include "timer0.h"
+
+
+/*
+* Function:
+* void timer0Init(void)
+*
+* initialise timer0. will be moved to its own module soon
+*
+* Inputs:
+* none
+*
+* Returns:
+* none
+*
+* Implementation:
+* TODO:[explain key steps of function] timer0 init
+* [use heavy detail for anything complicated]
+*
+* Improvements:
+* Move to its own module.
+*
+*/
+void timer0Init(void)
+{
+	////TIMER0////
+	//Timer0 is used for delay_ms and get_ms functions required by the imu driver
+	REG_PMC_PCER0
+	|=	(1<<ID_TC0);						//Enable TC clock (ID_TC0 is the peripheral identifier
+	//for timer counter 0)
+	NVIC_EnableIRQ(ID_TC0);					//Enable interrupt vector for TIMER0
+	REG_TC0_CMR0							//TC Channel Mode Register (Pg877)
+	|=	TC_CMR_TCCLKS_TIMER_CLOCK3			//Prescaler MCK/32 (100MHz/32 = 3.125MHz)
+	|	TC_CMR_WAVE							//Waveform mode
+	|	TC_CMR_WAVSEL_UP_RC;				//Clear on RC compare
+	REG_TC0_IER0							//TC interrupt enable register
+	|=	TC_IER_CPCS;						//Enable Register C compare interrupt
+	REG_TC0_RC0								//Set Register C (the timer counter value at which the
+	//interrupt will be triggered)
+	=	3125;								//Trigger once every 1/1000th of a second
+	//(100Mhz/32/1000)
+	REG_TC0_CCR0							//Clock control register
+	|=	TC_CCR_CLKEN						//Enable the timer clk.
+	|	TC_CCR_SWTRG;
+}
+
+/*
+* Function: int get_ms(uint32_t *timestamp)
+*
+* Required by the IMU drivers (hence naming convention). Outputs the system uptime generated from
+* Timer0.
+*
+* Inputs:
+* address of an integer where the timestamp will be stored
+*
+* Returns:
+* function will return 1 if invalid pointer is passed, otherwise a 0 on success
+*
+* Implementation:
+* Retrieves the value stored in systemTimestamp (stores the number of millisecs that have elapsed
+* since power on) and drops it at the address given by *timestamp. if *timestamp is an invalid
+* address then returns a 1.
+*
+*/
+int get_ms(uint32_t *timestamp)
+{
+	if(!timestamp)
+	return 1;
+	*timestamp = systemTimestamp;
+	return 0;
+}
+
+
+/*
+* Function: int delay_ms(uint32_t period_ms)
+*
+* Required by the IMU drivers (hence naming convention). Halts execution for desired number of
+* milliseconds.
+*
+* Inputs:
+* period_ms is the number of milliseconds to wait
+*
+* Returns:
+* Always returns 0
+*
+* Implementation:
+* Stores systemTimestamp at the start of the function, then waits until systemTimestamp has
+* increased by the amount given in period_ms before continuing.
+*
+*/
+int delay_ms(uint32_t period_ms)
+{
+	uint32_t startTime = systemTimestamp;
+	while(systemTimestamp < (startTime + period_ms));
+	return 0;
+}
+
+/*
+* Function: void TC0_Handler()
+*
+* Interrupt handler for Timer0. Is used to help implement get_ms() and delay_ms() functions
+* required by the IMU driver. Is also used to trigger reading the IMU's FIFO buffer (until
+* hardware interrupts are implemented). The only interrupt on Timer0 is on Register C compare,
+* which will trigger an interrupt once every millisecond
+*
+* Inputs:
+* none
+*
+* Returns:
+* Increments systemTimestamp once every millisecond.
+*
+* Implementation:
+* If the RC compare flag is set then it increments the systemTimestamp, and also checks if 5ms
+* has elapsed. If so, will set a flag to read from the IMU's FIFO buffer (unimplemented)
+*
+*/
+void TC0_Handler()
+{
+	//The interrupt handler for timer counter 0
+	//Triggers every 1ms
+	if(REG_TC0_SR0 & TC_SR_CPCS)									//If RC compare flag
+	{
+		systemTimestamp++;
+		streamDelayCounter++;
+		if(streamDelayCounter == 100) //used for streaming data
+		{
+			streamDelayCounter = 0;
+			streamIntervalFlag = 1;
+		}
+		//V1 robot doesn't have the IMU's interrupt pin tied in to the uC, so the FIFO will have to be
+		//polled. V2 does utilise an external interrupt, so this code is not necessary.
+		#if defined ROBOT_TARGET_V1
+		//Read IMUs FIFO every 5ms on the V1 platform
+		if(systemTimestamp >= (imuFifoNextReadTime + 5))
+		{
+			imuFifoNextReadTime = systemTimestamp;
+		}
+		#endif
+	}
+}

--- a/RobotNoASF/Interfaces/timer0.h
+++ b/RobotNoASF/Interfaces/timer0.h
@@ -78,6 +78,20 @@ int get_ms(uint32_t *timestamp);
 int delay_ms(uint32_t period_ms);
 
 /*
+* Function: int delay_us(uint32_t period_us)
+*
+* micro second delay
+*
+* Inputs:
+* period_us is the number of microseconds to wait
+*
+* Returns:
+* Always returns 0
+*
+*/
+int delay_us(uint32_t period_us);
+
+/*
 * Function: void TC0_Handler()
 *
 * Interrupt handler for Timer0. Is used to help implement get_ms() and delay_ms() functions
@@ -92,6 +106,6 @@ int delay_ms(uint32_t period_ms);
 * Increments systemTimestamp once every millisecond.
 *
 */
-void TC0_Handler();
+void TC1_Handler();
 
 #endif /* TIMER0_H_ */

--- a/RobotNoASF/Interfaces/timer0.h
+++ b/RobotNoASF/Interfaces/timer0.h
@@ -14,6 +14,9 @@
 //Flags and system globals
 uint32_t systemTimestamp = 0;	//Number of ms since powerup. Used by delay_ms and get_ms functions
 								//Which in turn are used by the IMU drivers/DMP
+								
+uint16_t usTimeStamp = 0;		//Number of us since last interrupt
+
 #if defined ROBOT_TARGET_V1
 uint32_t imuFifoNextReadTime = 0;//The system time at which the IMU will be read next (ie when
 //checkImuFifo will next be set to one. Used by the V1 robot

--- a/RobotNoASF/Interfaces/timer0.h
+++ b/RobotNoASF/Interfaces/timer0.h
@@ -1,0 +1,94 @@
+/*
+ * timer0.h
+ *
+ * Created: 6/08/2017 1:23:27 PM
+ *  Author: adams
+ */ 
+
+
+#ifndef TIMER0_H_
+#define TIMER0_H_
+
+#include "../robot_defines.h"
+
+//Flags and system globals
+uint32_t systemTimestamp = 0;	//Number of ms since powerup. Used by delay_ms and get_ms functions
+								//Which in turn are used by the IMU drivers/DMP
+#if defined ROBOT_TARGET_V1
+uint32_t imuFifoNextReadTime = 0;//The system time at which the IMU will be read next (ie when
+//checkImuFifo will next be set to one. Used by the V1 robot
+//only as the V2 sets checkImuInfo from external interrupt from
+//The IMU.
+#endif
+
+
+/*
+* Function:
+* void timer0Init(void)
+*
+* initialise timer0. will be moved to its own module soon
+*
+* Inputs:
+* none
+*
+* Returns:
+* none
+*
+* Implementation:
+* TODO:[explain key steps of function] timer0 init
+* [use heavy detail for anything complicated]
+*
+* Improvements:
+* Move to its own module.
+*
+*/
+void timer0Init(void);
+
+/*
+* Function: int get_ms(uint32_t *timestamp)
+*
+* Required by the IMU drivers (hence naming convention). Outputs the system uptime generated from
+* Timer0.
+*
+* Inputs:
+* address of an integer where the timestamp will be stored
+*
+* Returns:
+* function will return 1 if invalid pointer is passed, otherwise a 0 on success
+*
+*/
+int get_ms(uint32_t *timestamp);
+
+/*
+* Function: int delay_ms(uint32_t period_ms)
+*
+* Required by the IMU drivers (hence naming convention). Halts execution for desired number of
+* milliseconds.
+*
+* Inputs:
+* period_ms is the number of milliseconds to wait
+*
+* Returns:
+* Always returns 0
+*
+*/
+int delay_ms(uint32_t period_ms);
+
+/*
+* Function: void TC0_Handler()
+*
+* Interrupt handler for Timer0. Is used to help implement get_ms() and delay_ms() functions
+* required by the IMU driver. Is also used to trigger reading the IMU's FIFO buffer (until
+* hardware interrupts are implemented). The only interrupt on Timer0 is on Register C compare,
+* which will trigger an interrupt once every millisecond
+*
+* Inputs:
+* none
+*
+* Returns:
+* Increments systemTimestamp once every millisecond.
+*
+*/
+void TC0_Handler();
+
+#endif /* TIMER0_H_ */

--- a/RobotNoASF/swarm_robot_V1.cproj
+++ b/RobotNoASF/swarm_robot_V1.cproj
@@ -266,6 +266,12 @@
     <Compile Include="Interfaces\spi.h">
       <SubType>compile</SubType>
     </Compile>
+    <Compile Include="Interfaces\timer0.c">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Interfaces\timer0.h">
+      <SubType>compile</SubType>
+    </Compile>
     <Compile Include="Interfaces\twimux_interface.c">
       <SubType>compile</SubType>
     </Compile>

--- a/RobotNoASF/swarm_robot_V2.cproj
+++ b/RobotNoASF/swarm_robot_V2.cproj
@@ -266,6 +266,12 @@
     <Compile Include="Interfaces\spi.h">
       <SubType>compile</SubType>
     </Compile>
+    <Compile Include="Interfaces\timer0.c">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Interfaces\timer0.h">
+      <SubType>compile</SubType>
+    </Compile>
     <Compile Include="Interfaces\twimux_interface.c">
       <SubType>compile</SubType>
     </Compile>


### PR DESCRIPTION
Moves Timer0 to a new module

Using the camera timer frequency of 12.5MHz
Also uses counter 1 to generate ms and us interrupt functionality

Remains compatible with get_ms and delay_ms for the IMU
Adds a delay_us function for Esmond
Makes it easy to add time based interrupts (such as 100ms used for streaming data to PC)

Still needs commenting by myself
