### PR TITLE
Remove redundant line follower code for V1 robots

### DIFF
--- a/RobotNoASF/Functions/docking_functions.c
+++ b/RobotNoASF/Functions/docking_functions.c
@@ -124,6 +124,7 @@ void dockRobot(void)
 */
 void updateLineSensorStates(void)
 {
+#if defined ROBOT_TARGET_V2
 	uint8_t sensorValue;
 	
 	sensorValue = lfLineDetected(LF_OUTER_L);
@@ -141,6 +142,7 @@ void updateLineSensorStates(void)
 	sensorValue = lfLineDetected(LF_INNER_R);
 	if (sensorValue != NO_CHANGE)
 		lf.innerRight = sensorValue;
+#endif
 }
 
 /*
@@ -184,6 +186,7 @@ void updateLineSensorStates(void)
 */
 int8_t getLineDirection(void)
 {
+#if defined ROBOT_TARGET_V2
 	//Get updated sensor data
 	updateLineSensorStates();
 	//Combine sensor states from sensor structure into single byte that can be used by a switch
@@ -219,6 +222,7 @@ int8_t getLineDirection(void)
 		case 0x6:
 			return 0;		//Straight
 	}
+#endif
 	return 0;
 }
 
@@ -245,6 +249,7 @@ int8_t getLineDirection(void)
 */
 void followLine(void)
 {
+#if defined ROBOT_TARGET_V2
 	int8_t lineDirection = getLineDirection();
 	if (lineDirection > 0)			//Turn right
 		rotateRobot(CW, abs(lineDirection)*10);
@@ -266,4 +271,5 @@ void followLine(void)
 		FIN_2_L;
 		REG_PWM_CUPD2 = 0;			//rear
 	}
+#endif
 }

--- a/RobotNoASF/Interfaces/adc_interface.h
+++ b/RobotNoASF/Interfaces/adc_interface.h
@@ -35,12 +35,11 @@
 //	It appears that the line follow sensors aren't connected to ADC channels on the V1, and that the
 //	IR leds are always on.
 //		Line follower ADC channels version 2 robot
-#if defined ROBOT_TARGET_V2
 #define LF0_ADC_CH			13	// Far left
 #define LF1_ADC_CH			15	// Center left
 #define LF2_ADC_CH			0	// Center right
 #define LF3_ADC_CH			7	// Far right
-#endif
+
 //		Fast charge chip ADC channels
 #define FC_BATVOLT_ADC_CH	14	// Battery voltage level
 #define FC_BATTEMP_ADC_CH	9	// Battery temperature

--- a/RobotNoASF/Interfaces/line_sens_interface.c
+++ b/RobotNoASF/Interfaces/line_sens_interface.c
@@ -23,24 +23,26 @@
 #include "component/pio.h"
 
 ///////////////Functions////////////////////////////////////////////////////////////////////////////
-
+/*
+* Function:
+* void lfInit(void)
+*
+* Initialises Line sensors on V2 robots
+*
+* Inputs:
+* none
+*
+* Returns:
+* none
+*
+* Implementation:
+* Configures the LED control pin for output so that the line sensor LEDs can be turned on
+*
+*/
 void lfInit(void)
-#if defined ROBOT_TARGET_V1
+//Line followers are incorrectly wired on the V1, and are therefore unavailable.
 {
-	//Setup LF sensor pins for (binary) input
-	LF_OUTER_L_PORT->PIO_PER			//Enable LF_OUTER_L sensor pin
-	|=	LF_OUTER_L;
-	LF_INNER_L_PORT->PIO_PER			//Enable LF_INNER_L sensor pin
-	|=	LF_INNER_L;
-	LF_INNER_R_PORT->PIO_PER			//Enable LF_INNER_R sensor pin
-	|=	LF_INNER_R;
-	LF_OUTER_R_PORT->PIO_PER			//Enable LF_OUTER_R sensor pin
-	|=	LF_OUTER_R;
-}
-#endif
-
 #if defined ROBOT_TARGET_V2
-{
 	//Initialise PA8 (LFC) for output so LEDs can be turned on and off
 	LFC_PORT->PIO_PER
 	|=	LFC;
@@ -48,8 +50,8 @@ void lfInit(void)
 	|=	LFC;
 	
 	lfLedState(ON);
-}
 #endif
+}
 
 /*
 * Function:
@@ -72,20 +74,15 @@ void lfInit(void)
 *
 */
 void lfLedState(uint8_t ledState)
-#if defined ROBOT_TARGET_V1
+//There is no ability to turn the LEDs on or off on the V1 (Hard wired on)
 {
-	//There is no ability to turn the LEDs on or off on the V1 (Hard wired on)
-}
-#endif
-
 #if defined ROBOT_TARGET_V2
-{
 	if (ledState == OFF)
 		LFC_PORT->PIO_SODR |= LFC;	//Turn LEDs off
 	if (ledState == ON)
 		LFC_PORT->PIO_CODR |= LFC;	//Turn LEDs on
-}
 #endif
+}
 
 /*
 * Function:
@@ -116,29 +113,8 @@ void lfLedState(uint8_t ledState)
 *
 */
 uint8_t lfLineDetected(uint8_t lfSensor)
-#if defined ROBOT_TARGET_V1
 {
-	//Thresholds are set in hardware by pull up resistors
-	switch (lfSensor)			//Pick the selected sensor and output it's value.
-	{
-		case LF_OUTER_L:
-			return LF_OUTER_L_PORT->PIO_IDR & LF_OUTER_L;
-		
-		case LF_INNER_L:
-			return LF_INNER_L_PORT->PIO_IDR & LF_INNER_L;
-		
-		case LF_INNER_R:
-			return LF_INNER_R_PORT->PIO_IDR & LF_INNER_R;
-		
-		case LF_OUTER_R:
-			return LF_OUTER_R_PORT->PIO_IDR & LF_OUTER_R;
-	}
-	return 0;
-}
-#endif
-
 #if defined ROBOT_TARGET_V2
-{
 	uint16_t sensorData = 0;
 	sensorData = adcRead(lfSensor);
 	
@@ -146,7 +122,6 @@ uint8_t lfLineDetected(uint8_t lfSensor)
 		return LINE;						
 	if (sensorData < LF_THRESHOLD_L)	//if below threshold then white floor detected.
 		return NO_LINE;
-		
+#endif
 	return NO_CHANGE;
 }
-#endif

--- a/RobotNoASF/Interfaces/line_sens_interface.h
+++ b/RobotNoASF/Interfaces/line_sens_interface.h
@@ -32,21 +32,6 @@
 #define NO_LINE			0
 #define NO_CHANGE		2
 
-#if defined ROBOT_TARGET_V1
-//TODO: Layout defines for the PIO pins that the line followers are connected to. They aren't
-//connected to ADC channels, but they may still be able to work by setting the threshold through
-//their pull up resistors.
-#define LF_OUTER_L_PORT	(PIOA)			//Line follower 0 Port
-#define LF_INNER_L_PORT	(PIOC)			//Line follower 1 Port
-#define LF_INNER_R_PORT	(PIOC)			//Line follower 2 Port
-#define LF_OUTER_R_PORT	(PIOA)			//Line follower 3 Port
-#define LF_OUTER_L		(PIO_PA5)		//Line follower 0 PIO pin
-#define LF_INNER_L		(PIO_PC28)		//Line follower 1 PIO pin
-#define LF_INNER_R		(PIO_PC10)		//Line follower 2 PIO pin
-#define LF_OUTER_R		(PIO_PA2)		//Line follower 3 PIO pin
-#endif
-
-#if defined ROBOT_TARGET_V2
 //#define LF_THRESHOLD_H	545				//Upper Threshold above which line is no longer detected
 //#define LF_THRESHOLD_L	235				//Lower threshold below which line is detected
 //Thresholds for insensitive sensor on Red V2
@@ -58,9 +43,21 @@
 #define LF_OUTER_R		(LF3_ADC_CH)	//Line follower 3 ADC channel
 #define LFC_PORT		(PIOA)			//PIO Port def for the line follower LED control
 #define LFC				(PIO_PA8)		//PIO pin def for the line follower LED control
-#endif
 
 ///////////////Functions////////////////////////////////////////////////////////////////////////////
+/*
+* Function:
+* void lfInit(void)
+*
+* Initialises Line sensors on V2 robots
+*
+* Inputs:
+* none
+*
+* Returns:
+* none
+*
+*/
 void lfInit(void);
 
 /*


### PR DESCRIPTION
V1 robots' line followers aren't wired to ADC channels and do not work. Removed code to tidy things up and remove warnings.